### PR TITLE
Excess line fix #1

### DIFF
--- a/Caesar Cipher/Caesar Cipher In Class.cpp
+++ b/Caesar Cipher/Caesar Cipher In Class.cpp
@@ -19,7 +19,7 @@ private:
 
 void Cipher::getInput()
 {
-	cout << "Enter message to encrypt/decrypt\n(place two spaces before typing sentence the first time)\n\n--> ";
+	cout << "Enter message to encrypt/decrypt\n\n--> ";
 	cin >> ws;
 	cin.getline(message, 1000);
 	system("cls");


### PR DESCRIPTION
Removed the information line to request users to add 2 whitespace before input due to the `cin.getline` loop error. Error has been fixed.